### PR TITLE
add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+install:
+  - go get -t -v ./...
+
+script:
+  - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status][travis-image]][travis-url] 
 # gosexy/gettext
 
 Go bindings for [GNU gettext][1], an internationalization and localization
@@ -105,3 +106,7 @@ And here's a [good tutorial][2] on using gettext.
 
 [1]: http://www.gnu.org/software/gettext/
 [2]: http://oriya.sarovar.org/docs/gettext_single.html
+
+
+[travis-image]: https://travis-ci.org/gosexy/gettext.svg?branch=master
+[travis-url]: https://travis-ci.org/gosexy/gettext


### PR DESCRIPTION
This is a tiny branch that just adds basic `.travis.yml` integration.

 Before you merge you need to flick the repository switch on in travis-ci.org under your account. Then you should see the travis build and the travis banner in your readme :)

Note that the build fails right now, which I can also reproduce locally. I bisected it and it starts breaking with commit 5269cf26ba096845b4a62901b7b1ebb49781177a on ubuntu. This might be a linux specific issue but before digging into it I wanted to add thetravis support first in order to avoid this kind of issue in the future.

Thanks for your consideration!
