### PR TITLE
Bugfix/fix tests on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+install:
+  - go get -t -v ./...
+
+script:
+  - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status][travis-image]][travis-url] 
 # gosexy/gettext
 
 Go bindings for [GNU gettext][1], an internationalization and localization
@@ -105,3 +106,7 @@ And here's a [good tutorial][2] on using gettext.
 
 [1]: http://www.gnu.org/software/gettext/
 [2]: http://oriya.sarovar.org/docs/gettext_single.html
+
+
+[travis-image]: https://travis-ci.org/gosexy/gettext.svg?branch=master
+[travis-url]: https://travis-ci.org/gosexy/gettext

--- a/gettext_test.go
+++ b/gettext_test.go
@@ -1,6 +1,7 @@
 package gettext
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,13 +13,16 @@ const (
 	frenchFrance       = "fr_FR.utf8"
 )
 
-func TestSpanish(t *testing.T) {
-	SetLocale(LcAll, spanishMexico)
-
+// a setUp would be nice
+func init() {
 	textDomain := "example"
-
 	BindTextdomain(textDomain, "_examples/")
 	Textdomain(textDomain)
+}
+
+func TestSpanish(t *testing.T) {
+	os.Setenv("LANGUAGE", spanishMexico)
+	SetLocale(LcAll, "")
 
 	assert.Equal(t, "¡Hola mundo!", Gettext("Hello, world!"))
 
@@ -32,7 +36,8 @@ func TestSpanish(t *testing.T) {
 }
 
 func TestDeutsch(t *testing.T) {
-	SetLocale(LcAll, deutschDeutschland)
+	os.Setenv("LANGUAGE", deutschDeutschland)
+	SetLocale(LcAll, "")
 
 	assert.Equal(t, "Hallo, Welt!", Gettext("Hello, world!"))
 
@@ -47,8 +52,8 @@ func TestDeutsch(t *testing.T) {
 
 func TestFrench(t *testing.T) {
 	// Note that we don't have a french translation.
-
-	SetLocale(LcAll, frenchFrance)
+	os.Setenv("LANGUAGE", frenchFrance)
+	SetLocale(LcAll, "")
 
 	assert.Equal(t, "Hello, world!", Gettext("Hello, world!"))
 


### PR DESCRIPTION
Trivial fix, build on top of the previosu travis.yml branch to verify it works on travis too (and not only in my local machine :)

Unfortunately I have no good explanation on the WHY. Setting the environment via the environment works, setting it via setlocale() does not. I looked into glibcs locale code but got lost in the twisted maze of `_nl_global_locale.__names[category]`. However I think the following is happening:

On ubuntu there is only a subset of locales enables by default `(locale -a` tells which). So setlocale() on my system for spanish fails and this makes the test fail. Same on travis where the only locale is english. However gettext and locale are two different parts of glibc. So setlocale fails (return return value is "") but thats ok because in gcigettext.c it will use guess_category_value() which will look into the LANGUAGE environment to find the right language (thats the theory from my incomplete understanding of the glibc code).

I am not very happy about this branch, but it seems like this is really a bit tricky to test properly.
